### PR TITLE
Fix settlement logic and add oracle injection

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -7,10 +7,11 @@ import "../contracts/BlobParimutuel.sol";
 contract Deploy is Script {
     function run() external {
         vm.startBroadcast();
-        BlobOptionDesk desk = new BlobOptionDesk();
-        BlobParimutuel pm = new BlobParimutuel();
+        address oracle = vm.envAddress("BLOB_ORACLE");
+        BlobOptionDesk desk = new BlobOptionDesk(oracle);
+        BlobParimutuel pm  = new BlobParimutuel(oracle);
         console.log("BBOD:", address(desk));
         console.log("BSP :", address(pm));
         vm.stopBroadcast();
     }
-} 
+}

--- a/test/BBOD.t.sol
+++ b/test/BBOD.t.sol
@@ -6,7 +6,7 @@ import "../contracts/BlobOptionDesk.sol";
 contract BBODFuzz is Test {
     BlobOptionDesk desk;
     address buyer = address(0xBEEF);
-    function setUp() public { desk = new BlobOptionDesk(); }
+    function setUp() public { desk = new BlobOptionDesk(address(0)); }
 
     function testFuzz(uint96 fee,uint96 strike) public {
         fee   = uint96(bound(fee,0,200));

--- a/test/BSP.t.sol
+++ b/test/BSP.t.sol
@@ -10,14 +10,14 @@ contract BSPFuzz is Test {
     // allow this contract to receive ether (rake)
     receive() external payable {}
 
-    function setUp() public { 
-        pm = new BlobParimutuel(); 
+    function setUp() public {
+        pm = new BlobParimutuel(address(0));
     }
 
     function testFuzz(uint96 fee, uint96 betAmount) public {
         fee = uint96(bound(fee,0,200));
         betAmount = uint96(bound(betAmount,1e16,10 ether));
-        pm = new BlobParimutuel();
+        pm = new BlobParimutuel(address(0));
 
         // Place HI bet
         vm.deal(bettor, betAmount);
@@ -41,7 +41,7 @@ contract BSPFuzz is Test {
         pm.settle();
 
         // Destructure the round tuple
-        (uint256 closeTs, uint256 hiPool, uint256 loPool, uint256 feeWei, uint256 thresholdGwei) = pm.rounds(1);
+        (uint256 closeTs, uint256 hiPool, uint256 loPool, uint256 feeWei, uint256 thresholdGwei, uint256 settlePriceGwei) = pm.rounds(1);
         bool hiWin = fee >= thresholdGwei;
         uint256 winPool = hiWin ? hiPool : loPool;
         vm.assume(winPool > 0);


### PR DESCRIPTION
## Summary
- allow BlobOptionDesk to manage multiple series
- refund margin when options expire worthless
- keep parimutuel rounds rolling hourly
- track settle prices per round
- make fee oracle address configurable
- remove global settled check from claim
- use `BLOB_ORACLE` env var for deployment

## Testing
- `forge test -vv` *(fails: `forge: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686284d91f60832cb4eef293c689dd83