### PR TITLE
Add missing Grafana provisioning

### DIFF
--- a/docker/grafana-provisioning/dashboards/dashboard.yaml
+++ b/docker/grafana-provisioning/dashboards/dashboard.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: default
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/docker/grafana-provisioning/dashboards/main.json
+++ b/docker/grafana-provisioning/dashboards/main.json
@@ -1,0 +1,65 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "Prometheus",
+        "enable": true,
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 168,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "showHeader": true
+      },
+      "title": "Prometheus up",
+      "type": "table",
+      "targets": [
+        {
+          "expr": "up",
+          "format": "time_series",
+          "interval": "",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Default Dashboard",
+  "uid": "default-dashboard",
+  "version": 1
+}

--- a/docker/grafana-provisioning/datasources/datasource.yaml
+++ b/docker/grafana-provisioning/datasources/datasource.yaml
@@ -1,0 +1,7 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090


### PR DESCRIPTION
## Summary
- add Grafana provisioning with default dashboards

## Testing
- `pnpm lint` *(fails: Command "lint" not found)*
- `pnpm format` *(fails: Command "format" not found)*
- `forge test -vv` *(fails: command not found)*
- `docker compose -f docker/docker-compose.yml up -d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68648ae6f99c832ca42ab8b7e0197de7