### PR TITLE
Go-live patch set

### DIFF
--- a/bots/commitRevealBot.ts
+++ b/bots/commitRevealBot.ts
@@ -1,0 +1,57 @@
+import { ethers } from "ethers";
+import Redis from "ioredis";
+import * as dotenv from "dotenv";
+dotenv.config();
+
+const redis = new Redis(process.env.REDIS || "redis://localhost:6379");
+const provider = new ethers.JsonRpcProvider(process.env.RPC!);
+const wallet   = new ethers.Wallet(process.env.PRIV!, provider);
+
+const pm = new ethers.Contract(
+  process.env.BSP!,
+  [
+    "event NewRound(uint256 indexed round,uint256 closeTs,uint256 revealTs,uint256 thresholdGwei)",
+    "event Settled(uint256 indexed round,uint256 feeGwei,uint256 rakeWei)",
+    "function commit(bytes32) external",
+    "function reveal(uint256,uint256) external"
+  ],
+  wallet
+);
+
+let latestFee = 0;
+let nonce = 0;
+const pending: Record<number,{thr:number,nonce:number}> = {};
+
+redis.subscribe("blobFee", "nextThreshold");
+redis.on("message", (_, msg) => {
+  if (_ === "blobFee") latestFee = Number(msg);
+  if (_ === "nextThreshold") latestFee = Number(msg);
+});
+
+pm.on("NewRound", async (id: bigint) => {
+  if (!latestFee) return;
+  nonce += 1;
+  const thr = latestFee;
+  const h = ethers.solidityPackedKeccak256(["uint256","uint256"],[thr, nonce]);
+  try {
+    await (await pm.commit(h)).wait();
+    pending[Number(id)+1] = { thr, nonce };
+    console.log(`commit round ${Number(id)+1} thr=${thr}`);
+  } catch (e) {
+    console.error("commit error", e);
+  }
+});
+
+pm.on("Settled", async (id: bigint) => {
+  const data = pending[Number(id)+1];
+  if (!data) return;
+  try {
+    await (await pm.reveal(data.thr, data.nonce)).wait();
+    delete pending[Number(id)+1];
+    console.log(`reveal round ${Number(id)+1} thr=${data.thr}`);
+  } catch (e) {
+    console.error("reveal error", e);
+  }
+});
+
+console.log("commitRevealBot running…");

--- a/contracts/BlobFeeOracle.sol
+++ b/contracts/BlobFeeOracle.sol
@@ -70,6 +70,7 @@ contract BlobFeeOracle is IBlobBaseFee {
     constructor(address[] memory _signers, uint256 _quorum) {
         require(_signers.length > 0 && _signers.length <= 256, "bad signers");
         require(_quorum > _signers.length/2, "quorum<50%");
+        require(_signers.length >= 2 && _quorum >= 2, "quorum < 2");
 
         signers = _signers;
         minSigners = _quorum;
@@ -137,6 +138,11 @@ contract BlobFeeOracle is IBlobBaseFee {
     /// @inheritdoc IBlobBaseFee
     function blobBaseFee() external view override returns (uint256) {
         return lastFee;
+    }
+
+    /// @notice Number of authorised signers.
+    function signerCount() external view returns (uint256) {
+        return signers.length;
     }
 
     /// @dev Count set bits using Brian Kernighan's algorithm.

--- a/contracts/BlobOptionDesk.sol
+++ b/contracts/BlobOptionDesk.sol
@@ -157,11 +157,11 @@ contract BlobOptionDesk is ReentrancyGuard {
     uint256 public constant GRACE_PERIOD = 6 hours;
 
     /// @notice sweep remaining margin after all exercises or timeout
-    function sweepMargin(uint256 id) external {
+    function sweepMargin(uint256 id) external nonReentrant {
         Series storage s = series[id];
+        require(msg.sender == writer, "!writer");
         require(seriesSettled[id], "unsettled");
-        require(s.margin > 0, "none");
-        require(s.sold == 0 || block.timestamp > s.expiry + GRACE_PERIOD, "pending");
+        require(s.payWei == 0, "ITM");
         uint256 amt = s.margin;
         s.margin = 0;
         payable(writer).transfer(amt);

--- a/contracts/BlobParimutuel.sol
+++ b/contracts/BlobParimutuel.sol
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
+
+// Deprecated in favour of CommitRevealBSP
 import "./BaseBlobVault.sol";
 import "./IBlobBaseFee.sol";
 import "lib/openzeppelin-contracts/contracts/utils/ReentrancyGuard.sol";

--- a/daemon/blobDaemon.ts
+++ b/daemon/blobDaemon.ts
@@ -9,10 +9,7 @@ const PROVIDER = new ethers.JsonRpcProvider(process.env.RPC!);
 const wallet = new ethers.Wallet(process.env.PRIV!, PROVIDER);
 const bParimutuel = new ethers.Contract(
   process.env.BSP!,
-  [
-    "function settle() external",
-    "function setNextThreshold(uint256) external"
-  ],
+  ["function settle() external"],
   wallet
 );
 
@@ -58,8 +55,8 @@ async function blobFeeGwei(): Promise<number> {
         const tx = await bParimutuel.settle({ gasLimit: 200_000 });
         console.log(`settle sent`, tx.hash);
 
-        // After a successful settlement, roll the threshold forward.
-        await (await bParimutuel.setNextThreshold(fee)).wait();
+        // broadcast next threshold for commitRevealBot
+        await redis.publish("nextThreshold", fee.toString());
 
         lastHour = hr; // update only on success
       } catch (e) {

--- a/ops/GO_LIVE_CHECKLIST.md
+++ b/ops/GO_LIVE_CHECKLIST.md
@@ -1,0 +1,6 @@
+- [ ] Safe owners confirmed & hardware wallets tested
+- [ ] 3 oracle feeders online (distinct RPCs)
+- [ ] commitRevealBot + daemon + settleBot on PM2 with restart-on-fail
+- [ ] 8 ETH gas buffer in Safe “ops” wallet
+- [ ] Verified contracts on Etherscan
+- [ ] Front-end NEXT_PUBLIC_* envs set & redeployed

--- a/scripts/SafeDeploy.ts
+++ b/scripts/SafeDeploy.ts
@@ -1,0 +1,45 @@
+import { ethers } from "ethers";
+import { EthersAdapter, SafeAccountConfig, SafeFactory } from "@safe-global/safe-core-sdk";
+import * as dotenv from "dotenv";
+import fs from "fs";
+import path from "path";
+
+dotenv.config();
+
+async function main() {
+  const provider = new ethers.JsonRpcProvider(process.env.RPC!);
+  const signer = new ethers.Wallet(process.env.PRIV!, provider);
+  const ethAdapter = new EthersAdapter({ ethers, signerOrProvider: signer });
+
+  const factory = await SafeFactory.create({ ethAdapter });
+  const safe = await factory.connectSafe(process.env.SAFE_ADDRESS!);
+
+  const Oracle = await (new ethers.ContractFactory(
+    (await import("../out/BlobFeeOracle.sol/BlobFeeOracle.json")).abi,
+    (await import("../out/BlobFeeOracle.sol/BlobFeeOracle.json")).bytecode,
+    signer
+  )).deploy([]);
+  await Oracle.waitForDeployment();
+
+  const Desk = await (new ethers.ContractFactory(
+    (await import("../out/BlobOptionDesk.sol/BlobOptionDesk.json")).abi,
+    (await import("../out/BlobOptionDesk.sol/BlobOptionDesk.json")).bytecode,
+    signer
+  )).deploy(await Oracle.getAddress());
+  await Desk.waitForDeployment();
+
+  const BSP = await (new ethers.ContractFactory(
+    (await import("../out/CommitRevealBSP.sol/CommitRevealBSP.json")).abi,
+    (await import("../out/CommitRevealBSP.sol/CommitRevealBSP.json")).bytecode,
+    signer
+  )).deploy(await Oracle.getAddress());
+  await BSP.waitForDeployment();
+
+  const envPath = path.resolve(__dirname, "../.env");
+  fs.appendFileSync(envPath, `\nORACLE=${await Oracle.getAddress()}\nBBOD=${await Desk.getAddress()}\nBSP=${await BSP.getAddress()}\n`);
+  console.log("Oracle", await Oracle.getAddress());
+  console.log("Desk", await Desk.getAddress());
+  console.log("BSP", await BSP.getAddress());
+}
+
+main().catch((e)=>{ console.error(e); process.exit(1); });

--- a/test/BBOD_Sweep.t.sol
+++ b/test/BBOD_Sweep.t.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.23;
+import "forge-std/Test.sol";
+import "../contracts/BlobOptionDesk.sol";
+import "../contracts/BlobFeeOracle.sol";
+import "lib/openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
+import "lib/openzeppelin-contracts/contracts/utils/cryptography/MessageHashUtils.sol";
+using ECDSA for bytes32;
+using MessageHashUtils for bytes32;
+
+contract BBODSweep is Test {
+    BlobOptionDesk desk;
+    BlobFeeOracle oracle;
+    uint256 PK = 0xA11CE;
+    address signer;
+
+    function setUp() public {
+        signer = vm.addr(PK);
+        address[] memory signers = new address[](1);
+        signers[0] = signer;
+        oracle = new BlobFeeOracle(signers, 1);
+        desk = new BlobOptionDesk(address(oracle));
+    }
+
+    function _push(uint256 fee) internal {
+        bytes32 h = keccak256(abi.encodePacked("BLOB_FEE", fee, block.timestamp/12));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(PK, h.toEthSignedMessageHash());
+        bytes[] memory sigs = new bytes[](1);
+        sigs[0] = abi.encodePacked(r, s, v);
+        oracle.push(fee, sigs);
+    }
+
+    function testSweepMarginOTM() public {
+        uint256 expiry = block.timestamp + 1 hours;
+        desk.create{value: 1 ether}(1, 100, 120, expiry, 1);
+        vm.warp(expiry + 1);
+        _push(90); // below strike => OTM
+        desk.settle(1);
+        uint256 balBefore = address(this).balance;
+        desk.sweepMargin(1);
+        assertEq(address(this).balance, balBefore + 1 ether);
+    }
+}


### PR DESCRIPTION
## Summary
- enforce constructor quorum and expose signer count
- add threshold commit/reveal flow
- update option desk margin sweep logic
- deprecate BlobParimutuel contract
- introduce commitRevealBot and safe deploy script
- publish nextThreshold via daemon
- add go-live checklist and new tests

## Testing
- `forge build` *(fails: command not found)*
- `pnpm lint` *(fails: no script defined)*

------
https://chatgpt.com/codex/tasks/task_e_6865f1ffee74832c8532af68667dbb82