### PR TITLE
feat(security): quorum oracle, intrinsic premium, threshold-lock

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,11 @@
+# Migration Guide
+
+## BlobFeeOracle
+- Constructor now `BlobFeeOracle(address[] signers, uint256 minSigners)`.
+- New `push(FeedMsg, bytes[])` requires EIP-712 signatures from at least `minSigners` addresses.
+
+## Off-chain Oracle Bot
+- Replace feedA/B with `daemon/oracleBot.ts`.
+- Configure `.env` with `ORACLE_KEYS` (comma separated private keys) used for signing.
+
+Run the bot with `pnpm ts-node daemon/oracleBot.ts`.

--- a/daemon/oracleBot.ts
+++ b/daemon/oracleBot.ts
@@ -1,0 +1,38 @@
+import { ethers } from "ethers";
+import "dotenv/config";
+
+const provider = new ethers.JsonRpcProvider(process.env.RPC!);
+const keys = process.env.ORACLE_KEYS!.split(",");
+const signers = keys.map(k => new ethers.Wallet(k, provider));
+
+const oracle = new ethers.Contract(
+  process.env.ORACLE!,
+  ["function push((uint256 fee,uint256 deadline),bytes[] sigs) external"],
+  signers[0]
+);
+
+(async () => {
+  const network = await provider.getNetwork();
+  const domain = {
+    name: "BlobFeeOracle",
+    version: "1",
+    chainId: Number(network.chainId),
+    verifyingContract: oracle.target as string,
+  };
+  const types = { FeedMsg: [{ name: "fee", type: "uint256" }, { name: "deadline", type: "uint256" }] };
+
+  async function publish() {
+    const fee: number = await provider.send("eth_blobBaseFee", []);
+    const deadline = Math.floor(Date.now() / 1000) + 30;
+    const message = { fee, deadline };
+    const sigs: string[] = [];
+    for (const w of signers) {
+      sigs.push(await w.signTypedData(domain, types, message));
+    }
+    const tx = await oracle.push(message, sigs);
+    console.log(`pushed ${fee} gwei -> ${tx.hash}`);
+  }
+
+  setInterval(publish, 12_000);
+  console.log("oracleBot running…");
+})();

--- a/test/BBOD.t.sol
+++ b/test/BBOD.t.sol
@@ -45,11 +45,20 @@ contract BBODFuzz is Test {
         // time passes + oracle push
         vm.warp(block.timestamp + 1 hours + 1);
         // sign and push fee
-        bytes32 digest = keccak256(abi.encodePacked("BLOB_FEE", uint256(fee), block.timestamp/12));
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(PK, digest.toEthSignedMessageHash());
+        uint256 dl = block.timestamp + 30;
+        bytes32 domain = keccak256(abi.encode(
+            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+            keccak256(bytes("BlobFeeOracle")),
+            keccak256(bytes("1")),
+            block.chainid,
+            address(oracle)
+        ));
+        bytes32 structHash = keccak256(abi.encode(keccak256("FeedMsg(uint256 fee,uint256 deadline)"), uint256(fee), dl));
+        bytes32 digest = MessageHashUtils.toTypedDataHash(domain, structHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(PK, digest);
         bytes[] memory sigs = new bytes[](1);
         sigs[0] = abi.encodePacked(r, s, v);
-        oracle.push(fee, sigs);
+        oracle.push(BlobFeeOracle.FeedMsg({fee: fee, deadline: dl}), sigs);
 
         // settle
         desk.settle(1);

--- a/test/OptionDeskEdge.t.sol
+++ b/test/OptionDeskEdge.t.sol
@@ -43,12 +43,25 @@ contract OptionDeskEdge is Test {
         assertGt(newP, oldP, "premium not updated");
     }
 
+    bytes32 constant DOMAIN_SEPARATOR = keccak256(
+        abi.encode(
+            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+            keccak256(bytes("BlobFeeOracle")),
+            keccak256(bytes("1")),
+            block.chainid,
+            address(oracle)
+        )
+    );
+    bytes32 constant TYPEHASH = keccak256("FeedMsg(uint256 fee,uint256 deadline)");
+
     function _push(uint256 fee) internal {
-        bytes32 h = keccak256(abi.encodePacked("BLOB_FEE", fee, block.timestamp/12));
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(PK, h.toEthSignedMessageHash());
+        uint256 dl = block.timestamp + 30;
+        bytes32 structHash = keccak256(abi.encode(TYPEHASH, fee, dl));
+        bytes32 digest = MessageHashUtils.toTypedDataHash(DOMAIN_SEPARATOR, structHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(PK, digest);
         bytes[] memory sigs = new bytes[](1);
         sigs[0] = abi.encodePacked(r, s, v);
-        oracle.push(fee, sigs);
+        oracle.push(BlobFeeOracle.FeedMsg({fee: fee, deadline: dl}), sigs);
     }
 
     function testWithdrawMarginOTM() public {

--- a/test/WinnerlessParimutuel.t.sol
+++ b/test/WinnerlessParimutuel.t.sol
@@ -17,6 +17,8 @@ contract WinnerlessParimutuel is Test {
     address[] signers;
     uint256 private PK = 0xA11CE;
     address private signer;
+    bytes32 DOMAIN;
+    bytes32 constant TYPEHASH = keccak256("FeedMsg(uint256 fee,uint256 deadline)");
 
     receive() external payable {}
 
@@ -25,6 +27,15 @@ contract WinnerlessParimutuel is Test {
         signers.push(signer);
         oracle = new BlobFeeOracle(signers, 1);
         pm = new BlobParimutuel(address(oracle));
+        DOMAIN = keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256(bytes("BlobFeeOracle")),
+                keccak256(bytes("1")),
+                block.chainid,
+                address(oracle)
+            )
+        );
     }
 
     function testWinnerlessRefund() public {
@@ -41,11 +52,13 @@ contract WinnerlessParimutuel is Test {
 
         // produce signature for fee push
         uint256 fee = 1;
-        bytes32 digest = keccak256(abi.encodePacked("BLOB_FEE", fee, block.timestamp/12));
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(PK, digest.toEthSignedMessageHash());
+        uint256 dl = block.timestamp + 30;
+        bytes32 structHash = keccak256(abi.encode(TYPEHASH, fee, dl));
+        bytes32 digest = MessageHashUtils.toTypedDataHash(DOMAIN, structHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(PK, digest);
         bytes[] memory sigs = new bytes[](1);
         sigs[0] = abi.encodePacked(r, s, v);
-        oracle.push(fee, sigs);
+        oracle.push(BlobFeeOracle.FeedMsg({fee: fee, deadline: dl}), sigs);
 
         pm.settle();
 
@@ -63,4 +76,26 @@ contract WinnerlessParimutuel is Test {
     function _getClose() internal view returns(uint256 close){
         (close,,,,,) = pm.rounds(1);
     }
-} 
+
+    function testThresholdLock() public {
+        vm.expectRevert("bet yet?");
+        pm.setThreshold(80);
+
+        vm.prank(bettor);
+        pm.betHi{value: 1 ether}();
+        pm.setThreshold(80);
+
+        uint256 close = _getClose();
+        vm.warp(close + 13);
+        uint256 dl = block.timestamp + 30;
+        bytes32 structHash = keccak256(abi.encode(TYPEHASH, uint256(50), dl));
+        bytes32 digest = MessageHashUtils.toTypedDataHash(DOMAIN, structHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(PK, digest);
+        bytes[] memory sigs = new bytes[](1);
+        sigs[0] = abi.encodePacked(r, s, v);
+        oracle.push(BlobFeeOracle.FeedMsg({fee: 50, deadline: dl}), sigs);
+        pm.settle();
+        (,,,, uint256 thr,) = pm.rounds(2);
+        assertEq(thr, 80);
+    }
+}


### PR DESCRIPTION
## Summary
- quorum-based `BlobFeeOracle` with EIP-712 signatures
- charge intrinsic + time value for options
- enforce `seriesMaxSold` limit and emit Purchase details
- lock parimutuel threshold once betting starts
- add off-chain `oracleBot.ts`
- migration guide for new constructor args and env vars

## Testing
- `pnpm format` *(fails: Command "format" not found)*
- `pnpm lint` *(fails: Command "lint" not found)*
- `forge test -vv` *(fails: forge not installed)*


------
https://chatgpt.com/codex/tasks/task_e_6867b9b175a4832cabe134ef6d005cac