### PR TITLE
Apply production fixes

### DIFF
--- a/contracts/BlobFeeOracle.sol
+++ b/contracts/BlobFeeOracle.sol
@@ -112,6 +112,10 @@ contract BlobFeeOracle is IBlobBaseFee, EIP712 {
         require(m.fee < 10_000, "fee-out-of-range");
         require(sigs.length >= minSigners, "quorum");
 
+        uint256 slot = block.timestamp / 12;
+        require(!slotPushed[slot], "already-pushed");
+        slotPushed[slot] = true;
+
         bytes32 digest = _hashTypedDataV4(
             keccak256(abi.encode(FEED_TYPEHASH, m.fee, m.deadline))
         );

--- a/test/BSP.t.sol
+++ b/test/BSP.t.sol
@@ -56,7 +56,7 @@ contract BSPFuzz is Test {
         pm.reveal(CommitRevealBSP.Side.Hi, salt);
 
         // 3. Forward to settlement (after reveal window end)
-        ( , , uint256 revealTs, , , , , , ) = pm.rounds(1);
+        ( , , uint256 revealTs, , , , , , , ) = pm.rounds(1);
         vm.warp(revealTs + 1);
 
         uint256 dl = block.timestamp + 30;
@@ -92,7 +92,7 @@ contract BSPFuzz is Test {
         vm.prank(bettor);
         pm.reveal(CommitRevealBSP.Side.Hi, salt);
 
-        (, , uint256 revealTs,,,,,,) = pm.rounds(1);
+        (, , uint256 revealTs,,,,,,,,) = pm.rounds(1);
         vm.warp(revealTs + 1);
         uint256 dl2 = block.timestamp + 30;
         bytes32 structHash2 = keccak256(abi.encode(TYPEHASH, uint256(50), dl2));
@@ -105,7 +105,7 @@ contract BSPFuzz is Test {
 
         // reveal threshold for round 2
         pm.reveal(fee, 1);
-        (, , , , , , uint256 thr,,) = pm.rounds(2);
+        (, , , , , , , uint256 thr,,,) = pm.rounds(2);
         assertEq(thr, fee);
     }
 }
@@ -127,7 +127,7 @@ contract BSPFuzz is Test {
         vm.prank(hi);
         pm.reveal(CommitRevealBSP.Side.Hi, saltH);
 
-        (, , uint256 revealTs,,,,,,) = pm.rounds(1);
+        (, , uint256 revealTs,,,,,,,,) = pm.rounds(1);
         vm.warp(revealTs + 1);
         uint256 dl3 = block.timestamp + 30;
         bytes32 structHash3 = keccak256(abi.encode(TYPEHASH, uint256(100), dl3));

--- a/test/BountySize.t.sol
+++ b/test/BountySize.t.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.23;
+import "forge-std/Test.sol";
+import "../contracts/CommitRevealBSP.sol";
+
+contract BountySize is Test {
+    CommitRevealBSP pm;
+    function setUp() public {
+        pm = new CommitRevealBSP(address(0));
+    }
+
+    receive() external payable {}
+
+    function testBountyIgnoresGifts() public {
+        // fund pools
+        pm.commit{value:1 ether}(keccak256(abi.encodePacked(address(1), CommitRevealBSP.Side.Hi, bytes32("s"))));
+        vm.warp(block.timestamp + 301);
+        vm.prank(address(1));
+        pm.reveal(CommitRevealBSP.Side.Hi, bytes32("s"));
+        (, , uint256 revealTs,,,,,,,,) = pm.rounds(1);
+        vm.warp(revealTs + 1);
+        // gift ETH to inflate address balance
+        payable(address(pm)).transfer(5 ether);
+        uint256 balBefore = address(this).balance;
+        pm.settle();
+        assertEq(address(this).balance - balBefore, 0); // bounty is zero due to zero pool
+    }
+}

--- a/test/OptionExpiryValidation.t.sol
+++ b/test/OptionExpiryValidation.t.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.23;
+import "forge-std/Test.sol";
+import "../contracts/BlobOptionDesk.sol";
+
+contract OptionExpiryValidation is Test {
+    BlobOptionDesk desk;
+    function setUp() public {
+        desk = new BlobOptionDesk(address(0));
+    }
+
+    function testBadExpiry() public {
+        vm.expectRevert("bad-expiry");
+        desk.create{value:1 ether}(1, 50, 75, block.timestamp, 1);
+    }
+}

--- a/test/OracleSlotFinality.t.sol
+++ b/test/OracleSlotFinality.t.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.23;
+import "forge-std/Test.sol";
+import "../contracts/BlobFeeOracle.sol";
+import "lib/openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
+import "lib/openzeppelin-contracts/contracts/utils/cryptography/MessageHashUtils.sol";
+using ECDSA for bytes32;
+using MessageHashUtils for bytes32;
+
+contract OracleSlotFinality is Test {
+    BlobFeeOracle oracle;
+    address signer = address(this);
+    bytes32 constant TYPEHASH = keccak256("FeedMsg(uint256 fee,uint256 deadline)");
+    bytes32 DOMAIN_SEPARATOR;
+
+    function setUp() public {
+        address[] memory signers = new address[](1);
+        signers[0] = signer;
+        oracle = new BlobFeeOracle(signers, 1);
+        DOMAIN_SEPARATOR = keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256(bytes("BlobFeeOracle")),
+                keccak256(bytes("1")),
+                block.chainid,
+                address(oracle)
+            )
+        );
+    }
+
+    function _sig(uint256 fee, uint256 dl) internal view returns(bytes[] memory sigs){
+        bytes32 structHash = keccak256(abi.encode(TYPEHASH, fee, dl));
+        bytes32 digest = MessageHashUtils.toTypedDataHash(DOMAIN_SEPARATOR, structHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(uint256(uint160(signer)), digest);
+        sigs = new bytes[](1);
+        sigs[0] = abi.encodePacked(r, s, v);
+    }
+
+    function testSlotSinglePush() public {
+        uint256 dl = block.timestamp + 30;
+        bytes[] memory sigs = _sig(50, dl);
+        oracle.push(BlobFeeOracle.FeedMsg({fee:50, deadline:dl}), sigs);
+        vm.expectRevert("already-pushed");
+        oracle.push(BlobFeeOracle.FeedMsg({fee:50, deadline:dl}), sigs);
+    }
+}

--- a/test/PremiumExact.t.sol
+++ b/test/PremiumExact.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.23;
+import "forge-std/Test.sol";
+import "../contracts/BlobOptionDesk.sol";
+
+contract PremiumExact is Test {
+    BlobOptionDesk desk;
+
+    function setUp() public {
+        desk = new BlobOptionDesk(address(0));
+        desk.create{value: 1 ether}(1, 50, 75, block.timestamp + 1 hours, 1);
+    }
+
+    function testRejectUnderpay() public {
+        uint256 p = desk.premium(50, block.timestamp + 1 hours);
+        vm.expectRevert("!prem");
+        desk.buy{value: p - 1}(1, 1);
+    }
+
+    function testRejectOverpay() public {
+        uint256 p = desk.premium(50, block.timestamp + 1 hours);
+        vm.expectRevert("!prem");
+        desk.buy{value: p + 1}(1, 1);
+    }
+}

--- a/test/ReentrantSettle.t.sol
+++ b/test/ReentrantSettle.t.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.23;
+import "forge-std/Test.sol";
+import "../contracts/CommitRevealBSP.sol";
+
+contract Attacker {
+    CommitRevealBSP pm;
+    constructor(address p) { pm = CommitRevealBSP(p); }
+    receive() external payable {
+        try pm.settle() {} catch {}
+    }
+    function attack() external { pm.settle(); }
+}
+
+contract ReentrantSettle is Test {
+    CommitRevealBSP pm;
+    Attacker atk;
+    function setUp() public {
+        pm = new CommitRevealBSP(address(0));
+        atk = new Attacker(address(pm));
+    }
+
+    function testReentrancyGuard() public {
+        pm.commit{value:1 ether}(keccak256(abi.encodePacked(address(atk), CommitRevealBSP.Side.Hi, bytes32("s"))));
+        vm.warp(block.timestamp + 301);
+        vm.prank(address(atk));
+        pm.reveal(CommitRevealBSP.Side.Hi, bytes32("s"));
+        (, , uint256 revealTs,,,,,,,,) = pm.rounds(1);
+        vm.warp(revealTs + 1);
+        vm.prank(address(atk));
+        vm.expectRevert();
+        atk.attack();
+    }
+}

--- a/test/ThresholdRevealEnforcement.t.sol
+++ b/test/ThresholdRevealEnforcement.t.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.23;
+import "forge-std/Test.sol";
+import "../contracts/CommitRevealBSP.sol";
+
+contract ThresholdRevealEnforcement is Test {
+    CommitRevealBSP pm;
+    function setUp() public {
+        pm = new CommitRevealBSP(address(0));
+    }
+
+    function testSettleRevertsIfUnrevealed() public {
+        // commit threshold for next round (round 2)
+        bytes32 h = keccak256(abi.encodePacked(uint256(50), uint256(1)));
+        pm.commit(h);
+
+        // settle round 1 (allowed even if next round unrevealed)
+        (, , uint256 revealTs1,,,,,,,,) = pm.rounds(1);
+        vm.warp(revealTs1 + 1);
+        pm.settle();
+
+        // attempt to settle round 2 without revealing threshold
+        (, , uint256 revealTs2,,,,,,,,) = pm.rounds(2);
+        vm.warp(revealTs2 + 1);
+        vm.expectRevert("threshold-not-revealed");
+        pm.settle();
+    }
+}

--- a/test/WriterPremiumUnlock.t.sol
+++ b/test/WriterPremiumUnlock.t.sol
@@ -37,4 +37,16 @@ contract WriterPremiumUnlock is Test {
         desk.withdrawPremium(id);
         assertGt(address(this).balance, balBefore, "premium not released");
     }
-} 
+
+    function testWithdrawTooEarly() public {
+        uint256 id = 1;
+        desk.create{value: 1 ether}(id, 50, 75, block.timestamp + 3600, 1);
+        uint256 p = desk.premium(50, block.timestamp + 3600);
+        vm.deal(address(1), p);
+        vm.prank(address(1));
+        desk.buy{value: p}(id, 1);
+        vm.expectRevert("locked");
+        desk.withdrawPremium(id);
+    }
+}
+


### PR DESCRIPTION
## Summary
- enforce cutoff and exact premium in option buys with withdrawal flow
- require threshold reveal before settlement and track bounty separately
- update tests for new struct and check premium payments
- add premium withdrawal guard and emit bounty in settled event

## Testing
- `pnpm lint` *(fails: Command "lint" not found)*
- `pnpm format` *(fails: Command "format" not found)*
- `forge test -vv` *(fails: forge: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b3f077a70832c9f6c47e9a0647246