### PR TITLE
Add reveal timeout fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The repository also ships monitoring and automation tools for production deploym
 ### Key Parameters
 
 - **BlobFeeOracle** – successive fee pushes may not deviate by more than 2x.
-- **CommitRevealBSP** – `REVEAL_TIMEOUT` of 15 minutes prevents threshold-freeze.
+- **CommitRevealBSP** – `REVEAL_TIMEOUT` of 15 minutes prevents threshold-freeze. `THRESHOLD_REVEAL_TIMEOUT` of 1 hour falls back to the previous threshold if unrevealed.
 - **BlobOptionDesk** – premium scale `k` defaults to `7e13`; margin withdrawal is possible after `GRACE_PERIOD` (1 day).
 
 


### PR DESCRIPTION
## Summary
- support fallback when threshold reveal not published
- document THRESHOLD_REVEAL_TIMEOUT
- test fallback to previous threshold after timeout

## Testing
- `pnpm lint` *(fails: Command "lint" not found)*
- `pnpm format` *(fails: Command "format" not found)*
- `forge test -vv` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b61d7cc3c832ca918307eb698b348