### PR TITLE
Add RPC uptime guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ For a resilient deployment run at least two oracle bot instances (on different p
 
 All contracts are permissionless once deployed but rely on timely feeds to remain safe. The oracle can be overridden via timelock only if signers stop pushing for a full day. Carefully manage private keys and RPC reliability to avoid stuck rounds.
 
+### RPC Uptime & Rate Limits
+
+Each bot requires a stable RPC endpoint. Aim for providers with >99.9% uptime and rate limits of at least 5-10 requests per second. Examples include Alchemy, Infura or Ankr. Where possible use separate RPC keys per bot to avoid throttling.
+
 **Risk Warning:** Options and parimutuel betting are inherently risky. Smart contract bugs, oracle failures or extreme volatility could lead to loss of funds. Run extensive tests on a fork before using real value.
 
 ---


### PR DESCRIPTION
## Summary
- document RPC uptime and rate limit recommendations

## Testing
- `pnpm lint`
- `pnpm format`
- ❌ `forge test -vv` *(failed: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686b6994376c832c97b1f8b4634d7513