### PR TITLE
Update README to document CI status

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,16 @@ Each bot requires a stable RPC endpoint. Aim for providers with >99.9% uptime an
 3. Submit a pull request with a clear description of your changes and test evidence.
 4. Maintain backward compatibility when touching on-chain code and document any new parameters or risks.
 
+### Continuous Integration
+
+Automated CI is not yet configured. All tests and lint checks must be run manually:
+
+- `forge test -vv`
+- `pnpm lint`
+- `pnpm format`
+
+Once CI is introduced, workflows will live under `.github/workflows/`.
+
 ## Security: How to protect your operator private key
 
 Never commit private keys or plaintext mnemonics. Use a hardware wallet or encrypted secret manager for production bots. Environment files should only reference key URIs, and access should be limited.


### PR DESCRIPTION
## Summary
- mention that CI is not yet configured and tests/lints must be run manually

## Testing
- `forge test -vv` *(fails: command not found)*
- `pnpm lint`
- `pnpm format`


------
https://chatgpt.com/codex/tasks/task_e_686b6c575d98832c9d3eecacba0c4869