### PR TITLE
Fix newline at EOF for foundry.toml

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -4,4 +4,4 @@ out = "out"
 libs = ["lib"]
 optimizer = true
 optimizer_runs = 500
-via_ir = true 
+via_ir = true


### PR DESCRIPTION
## Summary
- add a newline at the end of `foundry.toml`
- remove trailing whitespace on last line

## Testing
- `pnpm lint` *(fails: ESLint couldn't find a config)*
- `pnpm format` *(fails: prettier-plugin-solidity missing)*
- `forge test -vv` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc4d88fa8832cbfaae411256cff2c